### PR TITLE
Align Type_Bob with Gusto employment type

### DIFF
--- a/BOB<>Gusto
+++ b/BOB<>Gusto
@@ -445,7 +445,7 @@ function comparePairYesNo_(b, g, meta) {
     Status_Bob: status_b, Status_Gusto: status_g, Status_Match,
     TermDate_Bob: term_b, EndDate_Gusto: term_g, TermDate_Match,
 
-    Type_Bob: type_b, Type_Gusto: type_g, Type_Match,
+    Type_Bob: type_g, Type_Gusto: type_g, Type_Match,
     Amount_Bob: isNumber_(amt_b) ? amt_b : '', Amount_Gusto: isNumber_(amt_g) ? amt_g : '', Amount_Match,
 
     EffDate_Bob: eff_b, EffDate_Gusto: eff_g, EffDate_Match,


### PR DESCRIPTION
## Summary
- Ensure `Type_Bob` uses Gusto's employment type column

## Testing
- `node --check 'BOB<>Gusto' && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c82d8cc670832ba7cb6bee95b9eae3